### PR TITLE
Add button to open item menu to unobstruct content/tool options.

### DIFF
--- a/item_menu/cl_panels.lua
+++ b/item_menu/cl_panels.lua
@@ -142,3 +142,34 @@ function PANEL:Paint( w, h )
 end
 
 vgui.Register( "ixItemMenu", PANEL, "DFrame" )
+
+PANEL = {}
+
+function PANEL:Init()
+	if (IsValid(ix.gui.itemmenutoggle)) then
+		ix.gui.itemmenutoggle:Remove()
+	end
+
+	ix.gui.itemmenutoggle = self
+
+	self:SetSize(100, 100)
+	self:MakePopup()
+	self:SetScreenLock( true )
+	self:ShowCloseButton( false )
+	self:SetVisible( false )
+	self:SetTitle("")
+	self.opensessame = self:Add("DButton")
+	self.opensessame:Dock(FILL)
+	self.opensessame:SetText("Open Item Menu")
+	self.opensessame.DoClick = function()
+		vgui.Create("ixItemMenu")
+		ix.gui.itemmenu:SetVisible(true)
+		ix.gui.itemmenu:MoveTo( ScrW( ) - 350, 0, 0.2, 0, -1 )
+	end
+end
+
+function PANEL:Paint(w, h)
+	surface.SetDrawColor( 50, 50, 50, 150 )
+end
+
+vgui.Register("ixItemMenuToggle", PANEL, "DFrame")

--- a/item_menu/cl_plugin.lua
+++ b/item_menu/cl_plugin.lua
@@ -1,34 +1,38 @@
 function PLUGIN:OnContextMenuOpen( )
-    if ( IsValid( ix.gui.itemmenu ) ) then
-        ix.gui.itemmenu:SetVisible( true )
-        ix.gui.itemmenu:MoveTo( ScrW( ) - 350, 0, 0.2, 0, -1 )
-    end
+	if ( IsValid( ix.gui.itemmenutoggle ) ) then
+		ix.gui.itemmenutoggle:SetVisible( true )
+		ix.gui.itemmenutoggle:MoveTo( ScrW( ) - 350, 0, 0.2, 0, -1 )
+	end
 end
 
 function PLUGIN:OnContextMenuClose( )
-    if ( IsValid( ix.gui.itemmenu ) ) then
-        ix.gui.itemmenu:MoveTo( ScrW( ) + 350, 0, 0.2, 0, -1, function( )
-            ix.gui.itemmenu:SetVisible( false )
-        end )
+	if ( IsValid( ix.gui.itemmenutoggle ) and IsValid(ix.gui.itemmenu)) then
+		ix.gui.itemmenutoggle:MoveTo( ScrW( ) + 350, 0, 0.2, 0, -1, function( )
+			ix.gui.itemmenutoggle:SetVisible( false )
+		end )
+		ix.gui.itemmenu:MoveTo( ScrW( ) + 350, 0, 0.2, 0, -1, function( )
+			ix.gui.itemmenu:SetVisible( false )
+		end )
 
-        --for live debugging, uncommenting these will rebuild the panel each time you close the context menu, please don't enable this live.
-        --ix.gui.itemmenu:Remove( )
-        --vgui.Create( "ixItemMenu" )
-    end
+		--for live debugging, uncommenting these will rebuild the panel each time you close the context menu, please don't enable this live.
+		--ix.gui.itemmenu:Remove( )
+		--vgui.Create( "ixItemMenu" )
+	end
 end
 
 function PLUGIN:PlayerSpawn( client )
-    if self:CanPlayerUseItemMenu( client ) then
-        vgui.Create( "ixItemMenu" )
-    else
-        ix.gui.itemmenu:Remove( )
-    end
+	if self:CanPlayerUseItemMenu( client ) then
+		vgui.Create( "ixItemMenuToggle" )
+	else
+		ix.gui.itemmenutoggle:Remove()
+		ix.gui.itemmenu:Remove( )
+	end
 end
 
 local PLUGIN = PLUGIN
 
 hook.Add( "Think", "ixAdminMenuLoad", function( )
-    if not IsValid( ix.gui.itemmenu ) and PLUGIN:CanPlayerUseItemMenu( LocalPlayer( ) ) then
-        vgui.Create( "ixItemMenu" )
-    end
+	if not IsValid( ix.gui.itemmenutoggle ) and PLUGIN:CanPlayerUseItemMenu( LocalPlayer( ) ) then
+		vgui.Create( "ixItemMenuToggle" )
+	end
 end )


### PR DESCRIPTION
It's come to recent attention that the item menu, when opening the context menu, obstructs the tool options that are commonly found on the lower-right side of the authorized user's(AU) screen. This is to address that issue by having the AU click a button to open the item menu when they actually want to interact with it.